### PR TITLE
make the CloudWatch Logs group name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ module "flow_logs" {
   vpc_id = "${aws_vpc.main.id}"
 }
 ```
+
+See the [optional variables](variables.tf).

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,5 @@
 // https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html#flow-logs-iam
+
 data "template_file" "assume_role_policy" {
   template = "${file("${path.module}/assume_role_policy.json")}"
 }
@@ -8,7 +9,7 @@ data "template_file" "log_policy" {
 }
 
 resource "aws_cloudwatch_log_group" "flow_log_group" {
-  name = "${var.prefix}-flow-log"
+  name = "${var.log_group_name == "" ? local.default_log_group_name : var.log_group_name}"
 }
 
 resource "aws_iam_role" "iam_log_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,13 @@ variable "traffic_type" {
   default = "ALL"
   description = "https://www.terraform.io/docs/providers/aws/r/flow_log.html#traffic_type"
 }
+
+// workaround for not being able to do interpolation in variable defaults
+// https://github.com/hashicorp/terraform/issues/4084
+locals {
+  default_log_group_name = "${var.prefix}-flow-log"
+}
+variable "log_group_name" {
+  default = ""
+  description = "Defaults to `$${default_log_group_name}`"
+}


### PR DESCRIPTION
Before, the group name was fixed, albeit with a configurable prefix. This is a problem for existing systems that may want to adopt this module, since they might already have flow logs going to a log group with a different name. We want them to be able to use the same log group.