### PR TITLE
fix module `source` for Terraform v0.11+

### DIFF
--- a/test/network.tf
+++ b/test/network.tf
@@ -13,7 +13,7 @@ module "network" {
 }
 
 module "flow_logs" {
-  source = ".."
+  source = "../"
   vpc_id = "${module.network.vpc_id}"
   prefix = "${var.prefix}"
 }

--- a/test/network.tf
+++ b/test/network.tf
@@ -4,6 +4,7 @@ data "aws_region" "current" {
 
 module "network" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "~> 1.0"
 
   name = "terraform-vpc-flow-log-test"
   azs = ["${data.aws_region.current.name}d"]


### PR DESCRIPTION
Was being misinterpreted as a Terraform Registry module without the trailing slash.

https://www.terraform.io/upgrade-guides/0-11.html#relative-paths-in-module-source