### PR TITLE
Add support for terraform-docs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,20 @@ module "flow_logs" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| log_group_name | Defaults to `$${default_log_group_name}` | string | `` | no |
+| prefix | The prefix for the resource names. You will probably want to set this to the name of your VPC, if you have multiple. | string | `vpc` | no |
+| traffic_type | https://www.terraform.io/docs/providers/aws/r/flow_log.html#traffic_type | string | `ALL` | no |
+| vpc_id |  | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| log_group_name | The name of the created cloudwatch log group |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ module "flow_logs" {
 }
 ```
 
-See the [optional variables](variables.tf).
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,4 @@
 output "log_group_name" {
-  value = "${aws_flow_log.vpc_flow_log.log_group_name}"
+  description = "The name of the created cloudwatch log group"
+  value       = "${aws_flow_log.vpc_flow_log.log_group_name}"
 }


### PR DESCRIPTION
[terraform-docs](https://github.com/segmentio/terraform-docs) is a create tool to keep module parameter documentation up-to-date, especially when combined with [pre-commit](https://pre-commit.com/) hooks that can update documentation on every commit.

This change adds the necessary placeholders to README.md that are used by `terraform-docs` to update parameter documentation.