### PR TITLE
Replace deprecated aws_flow_log parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ resource "aws_cloudwatch_log_group" "flow_log_group" {
 }
 
 resource "aws_flow_log" "vpc_flow_log" {
-  log_group_name = "${aws_cloudwatch_log_group.flow_log_group.name}"
-  iam_role_arn   = "${aws_iam_role.iam_log_role.arn}"
-  vpc_id         = "${var.vpc_id}"
-  traffic_type   = "${var.traffic_type}"
+  log_destination = "${aws_cloudwatch_log_group.flow_log_group.arn}"
+  iam_role_arn    = "${aws_iam_role.iam_log_role.arn}"
+  vpc_id          = "${var.vpc_id}"
+  traffic_type    = "${var.traffic_type}"
 }


### PR DESCRIPTION
The `log_group_name` parameter has been deprecated in favour of the `log_destination` parameter, which takes the arn of the cloudwatch log group rather than the name.